### PR TITLE
build worked, some mysterious problem that just resolved after renami…

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -15,7 +15,7 @@ phases:
       - aws cloudfront create-invalidation --distribution-id=EM4IOR3AXZTHT --paths '/*'
 artifacts:
   files:
-    - "build/**/*"
+    - "dist/**/*"
   discard-paths: no
 #reports:
 #  jest_reports: # test reports


### PR DESCRIPTION
…ng Auth folder to Foo then back to Auth. this commit changed the buildspec artifact folder name from build to dist